### PR TITLE
mco package fails due to validation issues

### DIFF
--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -14,7 +14,7 @@ action "ps", :description => "Retrieve information about running containers" do
         :optional       => true,
         :display_as     => "Show All",
         :type           => :boolean,
-        :prompt         => "Show All",
+        :prompt         => "Show All"
 
     input :limit,
         :description    => "Limit result set",

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -97,10 +97,11 @@ action "stop", :description => "Stop a running container" do
 
     input :id,
         :description=> "Id",
+        :prompt     => "Container ID",
         :display_as => "Container ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
-        :optional   => :false,
+        :optional   => false,
         :maxlength  => 12
 
     output :exitcode,
@@ -113,6 +114,7 @@ action "kill", :description => "Kill a running container" do
 
     input :id,
         :description=> "Id",
+        :prompt     => "Container ID",
         :display_as => "Container ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
@@ -129,6 +131,7 @@ action "restart", :description => "Restart a running container" do
 
     input :id,
         :description=> "Id",
+        :prompt     => "Container ID",
         :display_as => "Container ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -13,8 +13,8 @@ action "ps", :description => "Retrieve information about running containers" do
         :description    => "Show all containers, not only running ones",
         :optional       => true,
         :display_as     => "Show All",
-        :type           => :boolean,
-        :prompt         => "Show All"
+        :prompt         => "Show All",
+        :type           => :boolean
 
     input :limit,
         :description    => "Limit result set",
@@ -51,6 +51,7 @@ action "inspect", :description => "Inspect container details" do
 
     input :id,
         :description    => "Id",
+        :prompt         => "Container ID",
         :display_as     => "Container ID",
         :type           => :string,
         :validation     => '^[a-fA-F0-9]+$',

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -9,136 +9,138 @@ metadata    :name        => "Docker Access Agent",
 
 action "ps", :description => "Retrieve information about running containers" do
 
-	input	:all,
-		:description 	=> "Show all containers, not only running ones",
-		:display_as	=> "Show All"
+    input :all,
+        :description    => "Show all containers, not only running ones",
+        :optional       => :true,
+        :display_as     => "Show All"
 
-	input	:limit,
-		:description	=> "Limit result set",
-		:display_as	=> "Limit results",
-		:type		=> :integer
+    input :limit,
+        :description    => "Limit result set",
+        :display_as     => "Limit results",
+        :optional       => :true,
+        :type           => :integer
 
-	input	:sinceId,
-		:description	=> "Show only containers created since containers with Id",
-		:display_as	=> "Since ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :sinceId,
+        :description    => "Show only containers created since containers with Id",
+        :display_as => "Since ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	input	:beforeId,
-		:description	=> "Show only containers created before containers with Id",
-		:display_as	=> "Before ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :beforeId,
+        :description    => "Show only containers created before containers with Id",
+        :display_as => "Before ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
     output :containers,
-	  :description => "Output from API call, map of containers with detail data",
-          :display_as  => "Containers"
+        :description => "Output from API call, map of containers with detail data",
+        :display_as  => "Containers"
 end
 
 action "inspect", :description => "Inspect container details" do
-	display :always
+    display :always
 
-	input	:id,
-		:description	=> "Id",
-		:display_as	=> "Container ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :id,
+        :description    => "Id",
+        :display_as => "Container ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	output :details,
-		:description	=> "Container details as map",
-		:display_as   => "Details"
+    output :details,
+        :description    => "Container details as map",
+        :display_as   => "Details"
 end
 
 action "diff", :description => "Show container changes" do
-	display :always
+    display :always
 
-	input	:id,
-		:description	=> "Id",
-		:display_as	=> "Container ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :id,
+        :description=> "Id",
+        :display_as => "Container ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	output :changes,
-		:description	=> "Container changes as map",
-		:display_as   => "Changes"
+    output :changes,
+        :description    => "Container changes as map",
+        :display_as   => "Changes"
 end
 
 action "start", :description => "Start a previously stopped container" do
-	display :always
+    display :always
 
-	input	:id,
-		:description	=> "Id",
-		:display_as	=> "Container ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :id,
+        :description=> "Id",
+        :display_as => "Container ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	output :exitcode,
-		:description	=> "return code of action",
-		:display_as   => "exitcode"
+    output :exitcode,
+        :description    => "return code of action",
+        :display_as     => "exitcode"
 end
 
 action "stop", :description => "Stop a running container" do
-	display :always
+    display :always
 
-	input	:id,
-		:description	=> "Id",
-		:display_as	=> "Container ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :id,
+        :description=> "Id",
+        :display_as => "Container ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	output :exitcode,
-		:description	=> "return code of action",
-		:display_as   => "exitcode"
+    output :exitcode,
+        :description    => "return code of action",
+        :display_as     => "exitcode"
 end
 
 action "kill", :description => "Kill a running container" do
-	display :always
+    display :always
 
-	input	:id,
-		:description	=> "Id",
-		:display_as	=> "Container ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :id,
+        :description=> "Id",
+        :display_as => "Container ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	output :exitcode,
-		:description	=> "return code of action",
-		:display_as   => "exitcode"
+    output :exitcode,
+        :description    => "return code of action",
+        :display_as     => "exitcode"
 end
 
 action "restart", :description => "Restart a running container" do
-	display :always
+    display :always
 
-	input	:id,
-		:description	=> "Id",
-		:display_as	=> "Container ID",
-		:type		=> :string,
-		:validation	=> '^[a-fA-F0-9]+$',
-		:optional	=> :false,
-		:maxlength	=> 12
+    input :id,
+        :description=> "Id",
+        :display_as => "Container ID",
+        :type       => :string,
+        :validation => '^[a-fA-F0-9]+$',
+        :optional   => :false,
+        :maxlength  => 12
 
-	output :exitcode,
-		:description	=> "return code of action",
-		:display_as   => "exitcode"
+    output :exitcode,
+        :description    => "return code of action",
+        :display_as     => "exitcode"
 end
 
 action "images", :description => "Retrieve information about all images on a host" do
 
     output :images,
-	  :description => "Output from API call, map of images with detail data",
-          :display_as  => "Images"
+        :description    => "Output from API call, map of images with detail data",
+        :display_as     => "Images"
 end
 

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -12,63 +12,66 @@ action "ps", :description => "Retrieve information about running containers" do
     input :all,
         :description    => "Show all containers, not only running ones",
         :optional       => true,
-        :display_as     => "Show All"
+        :display_as     => "Show All",
+        :prompt         => "Show All"
 
     input :limit,
         :description    => "Limit result set",
+        :prompt         => "Limit results",
         :display_as     => "Limit results",
         :optional       => true,
         :type           => :integer
 
     input :sinceId,
-        :prompt     => "Show only containers created since containers with Id",
-        :description=> "Show only containers created since containers with Id",
-        :display_as => "Since ID",
-        :type       => :string,
-        :validation => '^[a-fA-F0-9]+$',
-        :optional   => true,
-        :maxlength  => 12
+        :prompt         => "Show only containers created since containers with Id",
+        :description    => "Show only containers created since containers with Id",
+        :display_as     => "Since ID",
+        :type           => :string,
+        :validation     => '^[a-fA-F0-9]+$',
+        :optional       => true,
+        :maxlength      => 12
 
     input :beforeId,
-        :prompt     => "Show only containers created since containers with Id",
-        :description=> "Show only containers created before containers with Id",
-        :display_as => "Before ID",
-        :type       => :string,
-        :validation => '^[a-fA-F0-9]+$',
-        :optional   => true,
-        :maxlength  => 12
+        :prompt         => "Show only containers created since containers with Id",
+        :description    => "Show only containers created before containers with Id",
+        :display_as     => "Before ID",
+        :type           => :string,
+        :validation     => '^[a-fA-F0-9]+$',
+        :optional       => true,
+        :maxlength      => 12
 
     output :containers,
-        :description => "Output from API call, map of containers with detail data",
-        :display_as  => "Containers"
+        :description    => "Output from API call, map of containers with detail data",
+        :display_as     => "Containers"
 end
 
 action "inspect", :description => "Inspect container details" do
     display :always
 
     input :id,
-        :description=> "Id",
-        :display_as => "Container ID",
-        :type       => :string,
-        :validation => '^[a-fA-F0-9]+$',
-        :optional   => false,
-        :maxlength  => 12
+        :description    => "Id",
+        :display_as     => "Container ID",
+        :type           => :string,
+        :validation     => '^[a-fA-F0-9]+$',
+        :optional       => false,
+        :maxlength      => 12
 
     output :details,
         :description    => "Container details as map",
-        :display_as   => "Details"
+        :display_as     => "Details"
 end
 
 action "diff", :description => "Show container changes" do
     display :always
 
     input :id,
-        :description=> "Id",
-        :display_as => "Container ID",
-        :type       => :string,
-        :validation => '^[a-fA-F0-9]+$',
-        :optional   => false,
-        :maxlength  => 12
+        :description    => "Id",
+        :prompt         => "Container ID",
+        :display_as     => "Container ID",
+        :type           => :string,
+        :validation     => '^[a-fA-F0-9]+$',
+        :optional       => false,
+        :maxlength      => 12
 
     output :changes,
         :description    => "Container changes as map",

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -11,29 +11,31 @@ action "ps", :description => "Retrieve information about running containers" do
 
     input :all,
         :description    => "Show all containers, not only running ones",
-        :optional       => :true,
+        :optional       => true,
         :display_as     => "Show All"
 
     input :limit,
         :description    => "Limit result set",
         :display_as     => "Limit results",
-        :optional       => :true,
+        :optional       => true,
         :type           => :integer
 
     input :sinceId,
-        :description    => "Show only containers created since containers with Id",
+        :prompt     => "Show only containers created since containers with Id",
+        :description=> "Show only containers created since containers with Id",
         :display_as => "Since ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
-        :optional   => :false,
+        :optional   => true,
         :maxlength  => 12
 
     input :beforeId,
-        :description    => "Show only containers created before containers with Id",
+        :prompt     => "Show only containers created since containers with Id",
+        :description=> "Show only containers created before containers with Id",
         :display_as => "Before ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
-        :optional   => :false,
+        :optional   => true,
         :maxlength  => 12
 
     output :containers,
@@ -45,11 +47,11 @@ action "inspect", :description => "Inspect container details" do
     display :always
 
     input :id,
-        :description    => "Id",
+        :description=> "Id",
         :display_as => "Container ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
-        :optional   => :false,
+        :optional   => false,
         :maxlength  => 12
 
     output :details,
@@ -65,12 +67,12 @@ action "diff", :description => "Show container changes" do
         :display_as => "Container ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
-        :optional   => :false,
+        :optional   => false,
         :maxlength  => 12
 
     output :changes,
         :description    => "Container changes as map",
-        :display_as   => "Changes"
+        :display_as     => "Changes"
 end
 
 action "start", :description => "Start a previously stopped container" do
@@ -78,10 +80,11 @@ action "start", :description => "Start a previously stopped container" do
 
     input :id,
         :description=> "Id",
+        :prompt     => "Container ID",
         :display_as => "Container ID",
         :type       => :string,
         :validation => '^[a-fA-F0-9]+$',
-        :optional   => :false,
+        :optional   => false,
         :maxlength  => 12
 
     output :exitcode,

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "Docker Access Agent",
+metadata    :name        => "Docker",
             :description => "Agent to access the Docker API via MCollective",
             :author      => "Andreas Schmidt [@aschmidt75]",
             :license     => "Apache 2",

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "Docker",
+metadata    :name        => "Docker Access Agent",
             :description => "Agent to access the Docker API via MCollective",
             :author      => "Andreas Schmidt [@aschmidt75]",
             :license     => "Apache 2",

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -13,7 +13,8 @@ action "ps", :description => "Retrieve information about running containers" do
         :description    => "Show all containers, not only running ones",
         :optional       => true,
         :display_as     => "Show All",
-        :prompt         => "Show All"
+        :type           => :boolean
+        :prompt         => "Show All",
 
     input :limit,
         :description    => "Limit result set",

--- a/agent/docker.ddl
+++ b/agent/docker.ddl
@@ -13,7 +13,7 @@ action "ps", :description => "Retrieve information about running containers" do
         :description    => "Show all containers, not only running ones",
         :optional       => true,
         :display_as     => "Show All",
-        :type           => :boolean
+        :type           => :boolean,
         :prompt         => "Show All",
 
     input :limit,


### PR DESCRIPTION
When attempting to run `mco plugin package` I receive the following error:

`The plugin application failed to run, use -v for full error details: Input needs a :optional property`

This PR resolves the issue and allows for building of rpm/deb's
